### PR TITLE
Feature #38 - Implemented LaunchDecider::decide method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,18 @@
             <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.3.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/se/kth/dd2480/group25/assignment1/LaunchDecider.java
+++ b/src/main/java/se/kth/dd2480/group25/assignment1/LaunchDecider.java
@@ -1,16 +1,37 @@
 package se.kth.dd2480.group25.assignment1;
 
+import se.kth.dd2480.group25.assignment1.lic.LaunchInterceptorCondition;
+
+import java.util.List;
+
 public class LaunchDecider {
 
-	public static void main(String[] args) {
-		System.out.println("This application will decide whether to launch hypothetical ballistic countermeasures");
-	}
+    public static void main(String[] args) {
+        System.out.println("This application will decide whether to launch hypothetical ballistic countermeasures");
+    }
 
-	public void Decide(int numPoints, Coordinate[] coordinate, InputParameters parameters,
-					   LogicalConnectorMatrix logicalConnectorMatrix,
-					   UnlockingVector preliminaryUnlockingVector) {
-		boolean[] conditionsMetVector;
-		UnlockingMatrix preliminaryUnlockingMatrix;
-		UnlockingVector finalUnlockingVector;
-	}
+    public boolean decide(int numPoints, List<Coordinate> coordinates, InputParameters parameters,
+                          LogicalConnectorMatrix logicalConnectorMatrix, List<Boolean> preliminaryUnlockingVector) {
+
+        List<LaunchInterceptorCondition> launchInterceptorConditions = createLaunchInterceptorConditions();
+
+        List<Boolean> conditionsMetVector =
+            launchInterceptorConditions.stream().map(condition -> condition.evaluate(coordinates, parameters)).toList();
+
+        UnlockingMatrix preliminaryUnlockingMatrix = logicalConnectorMatrix.applyConditionsMetVector(
+            conditionsMetVector);
+
+        List<Boolean> finalUnlockingVector =
+            preliminaryUnlockingMatrix.applyPreliminaryUnlockingVector(preliminaryUnlockingVector);
+
+        boolean shouldLaunch = finalUnlockingVector.stream().allMatch(Boolean::booleanValue);
+
+        return shouldLaunch;
+    }
+
+    private List<LaunchInterceptorCondition> createLaunchInterceptorConditions() {
+        // TODO: Instantiate all LICs once ready
+        return List.of();
+    }
+
 }

--- a/src/main/java/se/kth/dd2480/group25/assignment1/LogicalConnectorMatrix.java
+++ b/src/main/java/se/kth/dd2480/group25/assignment1/LogicalConnectorMatrix.java
@@ -1,9 +1,15 @@
 package se.kth.dd2480.group25.assignment1;
 
-public class LogicalConnectorMatrix {
+import java.util.List;
 
+public class LogicalConnectorMatrix {
 
     public enum OPERATION {
         ANDD, ORR, NOTUSED
+    }
+
+    public UnlockingMatrix applyConditionsMetVector(List<Boolean> conditionsMetVector) {
+        //TODO: Implement
+        return null;
     }
 }

--- a/src/main/java/se/kth/dd2480/group25/assignment1/UnlockingMatrix.java
+++ b/src/main/java/se/kth/dd2480/group25/assignment1/UnlockingMatrix.java
@@ -1,5 +1,11 @@
 package se.kth.dd2480.group25.assignment1;
 
+import java.util.List;
+
 public class UnlockingMatrix {
 
+    public List<Boolean> applyPreliminaryUnlockingVector(List<Boolean> preliminaryUnlockingVector) {
+        // TODO: Return the Final unlocking vector
+        return null;
+    }
 }

--- a/src/main/java/se/kth/dd2480/group25/assignment1/UnlockingVector.java
+++ b/src/main/java/se/kth/dd2480/group25/assignment1/UnlockingVector.java
@@ -1,5 +1,0 @@
-package se.kth.dd2480.group25.assignment1;
-
-public class UnlockingVector {
-
-}

--- a/src/test/java/se/kth/dd2480/group25/assignment1/LaunchDeciderTest.java
+++ b/src/test/java/se/kth/dd2480/group25/assignment1/LaunchDeciderTest.java
@@ -1,0 +1,43 @@
+package se.kth.dd2480.group25.assignment1;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LaunchDeciderTest {
+
+    @Mock
+    private LogicalConnectorMatrix lcm;
+
+    @Mock
+    private UnlockingMatrix pum;
+
+    private LaunchDecider launchDecider = new LaunchDecider();
+
+    @Test
+    void mustAllowLaunch() {
+        when(lcm.applyConditionsMetVector(anyList())).thenReturn(pum);
+        when(pum.applyPreliminaryUnlockingVector(anyList())).thenReturn(List.of(true, true, true, true));
+
+        boolean result = launchDecider.decide(4, List.of(), new InputParameters(), lcm, List.of());
+        assertTrue(result);
+    }
+
+    @Test
+    void mustRejectLaunch() {
+        when(lcm.applyConditionsMetVector(anyList())).thenReturn(pum);
+        when(pum.applyPreliminaryUnlockingVector(anyList())).thenReturn(List.of(true, true, true, false));
+
+        boolean result = launchDecider.decide(4, List.of(), new InputParameters(), lcm, List.of());
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
The implementation of LogicalConnectorMatrix and UnlockingMatrix is
still outstanding before the decide method can run on actual data.
Similarly this means that the unit tests of LaunchDecider have to use
mocked versions of these classes.

Also removed UnlockingVector as it is no longer required. (Issue #25)